### PR TITLE
Parse navigator.appVersion properly

### DIFF
--- a/rng.js
+++ b/rng.js
@@ -34,8 +34,7 @@ if(rng_pool == null) {
       window.crypto.getRandomValues(ua);
       for(t = 0; t < 32; ++t)
         rng_pool[rng_pptr++] = ua[t];
-    }
-    if(navigator.appName == "Netscape" && navigator.appVersion < "5") {
+    } else if(navigator.appName == "Netscape" && parseInt(navigator.appVersion) < 5) {
       // Extract entropy (256 bits) from NS4 RNG if available
       var z = window.crypto.random(32);
       for(t = 0; t < z.length; ++t)


### PR DESCRIPTION
Although navigator.appVersion is still "5" in the latest version of
Firefox, in Iceweasel it is "47.0". Because this is less than "5",
the code tries to run window.crypto.random(), which is undefined.

Adding the else clause before the if statement means it doesn't matter
whether or not the appVersion check is correct or not.

This issue is preventing me from accessing a couple of my service
providers using Iceweasel, including my bank. I don't know if they're 
using your code as a library, or have just copied it, they wouldn't give 
me any details of where the code came from, but it would be nice to
have this fixed so it works properly if anyone takes a copy.